### PR TITLE
Remove useless "--------------+"  in GtkCalendar css

### DIFF
--- a/Menda/gtk-3.0/gtk-widgets.css
+++ b/Menda/gtk-3.0/gtk-widgets.css
@@ -261,7 +261,7 @@ GtkFlowBox .grid-child {
     background-image: linear-gradient(to bottom,
                                       @button_active_gradient_color_a,
                                       @button_active_gradient_color_b);
-    text-shadow: 0 -1px       ------------------+;
+    text-shadow: 0 -1px;
     icon-shadow: 0 -1px @button_active_text_shadow;
     box-shadow: inset 0 1px 2px alpha(black, 0.2);
     transition-duration: 50ms;


### PR DESCRIPTION
GtkCalendar header had probably a typo for its text-shadow attribute, which then make gtk throw a warning.